### PR TITLE
Fixed lib.php function

### DIFF
--- a/lib/utils/lib.php
+++ b/lib/utils/lib.php
@@ -587,7 +587,14 @@ function profiler_compute_inclusive_times($raw_data) {
        * calls a unique recursion-depth appended name (for example, foo@1).
        */
       profiler_error("Error in Raw Data: parent & child are both: $parent");
-      return;
+      
+      /**
+       * I am adding this continue here because on certain tideways_hxprof logs 
+       * this fails spectacularly, givind a null value to a foreach causing a warning
+       * and nothing to be outputted. We can safely just continue traversing
+       * the array ignoring this single case
+       */
+       continue;  
     }
 
     if (!isset($symbol_tab[$child])) {


### PR DESCRIPTION
Fixed issue when parent. was equal to child, causing the whole application to crash. This seems to happen with the tideways_xhprof PHP extension (at least this was my case).